### PR TITLE
make data type names more descriptive

### DIFF
--- a/altair_widgets/widget.py
+++ b/altair_widgets/widget.py
@@ -74,7 +74,7 @@ class Interact:
         """ Creates shelf to plot a dimension (includes buttons
         for data column, encoding, data type, function)"""
         cols = self.columns
-        types = ['auto', 'Q', 'O', 'N']
+        types = {'Auto-detect': 'auto', 'Quantitative': 'Q', 'Ordinal': 'O', 'Nominal': 'N'}
         encodings = ['x', 'y', 'color', 'text', 'shape', 'size', 'row',
                      'column']
         functions = [None, 'mean', 'min', 'max', 'median', 'average', 'sum',
@@ -82,7 +82,7 @@ class Interact:
                      'argmin', 'argmax']
 
         data = widgets.Dropdown(options=cols, description='data')
-        type_ = widgets.Dropdown(options=types, description='data_type')
+        type_ = widgets.Dropdown(options=types, description='data_type', value='auto')
         encoding = widgets.Dropdown(options=encodings, description='encoding',
                                     value=encodings[i])
         fns = widgets.Dropdown(options=functions, description='function')

--- a/altair_widgets/widget.py
+++ b/altair_widgets/widget.py
@@ -74,7 +74,8 @@ class Interact:
         """ Creates shelf to plot a dimension (includes buttons
         for data column, encoding, data type, function)"""
         cols = self.columns
-        types = {'Auto-detect': 'auto', 'Quantitative': 'Q', 'Ordinal': 'O', 'Nominal': 'N'}
+        types = {'Auto-detect': 'auto', 'Quantitative': 'Q', 'Ordinal': 'O', 'Nominal': 'N',
+                 'Temporal': 'T'}
         encodings = ['x', 'y', 'color', 'text', 'shape', 'size', 'row',
                      'column']
         functions = [None, 'mean', 'min', 'max', 'median', 'average', 'sum',


### PR DESCRIPTION
Unless you're familiar with vega the single letter encoding for data types is probably a little opaque. This code makes the data_type dropdown look like so:

<img width="983" alt="screen shot 2016-10-29 at 23 21 21" src="https://cloud.githubusercontent.com/assets/2088/19832555/fce7e314-9e2e-11e6-8bd0-f956b56d6b86.png">
